### PR TITLE
Update example simulation links (and correct name)

### DIFF
--- a/projects/agent-based-model-hash-ai.md
+++ b/projects/agent-based-model-hash-ai.md
@@ -1,23 +1,23 @@
 ---
 remote_theme: nhsx/nhsx-io-theme
-title: Building an NHS Agent Based Model in HashAi
-description: NHSX PhD Internship - Building an NHS Agent Based Model in HashAi
+title: Building an NHS Agent Based Model in HASH
+description: NHSX PhD Internship - Building an NHS Agent Based Model in HASH
 permalink: /agent-based-model-hash-ai/
 ---
 
-# Building an NHS Agent Based Model in HashAi
+# Building an NHS Agent Based Model in HASH
 
 **Keywords:**  Agent Based Modelling
 
-**Need:**  Agent based modelling is a powerful tool for simulating complex problems such as the spread of epidemics, consumer behaviour or congestion.  However, there are not many successful examples of applied agent based simulation in the NHS, partly due to finding an appropriate use-case and partly due to the level of complication in the model development.   Hash.ai have created an online intuitive tool which allows for this technique to be demonstrated in a transparent manner.  Using Hash or a similar tool, this project would seek to investigate the power of agent based simulations and their appropriate application for managing health services.
+**Need:**  Agent based modelling is a powerful tool for simulating complex problems such as the spread of epidemics, consumer behaviour or congestion.  However, there are not many successful examples of applied agent based simulation in the NHS, partly due to finding an appropriate use-case and partly due to the level of complication in the model development.  HASH have created an online intuitive tool which allows for this technique to be demonstrated in a transparent manner.  Using HASH or a similar tool, this project would seek to investigate the power of agent based simulations and their appropriate application for managing health services.
 
-**Current Knowledge/Examples & Possible Techniques/Approaches:**  Whilst other suitable tools may exist (Mesa (Python) or Repast (Java) frameworks), our discovery work has demonstrated that [Hash](https://hash.ai/) would allow a model to be created in the timeframes for this project and that the learnings would be transferable and open.  Example simulations can be found at [Hash - Complex Systems Simulation](https://hash.ai/) as well as [a guide to using the HASH process modeling library and visual interface](https://docs.hash.ai/core/concepts/designing-with-process-models).  However, if a candidate brings experience/knowledge of an alternative open framework for building these models, then the project could focus on demonstrating a use-case through their recommended tool. 
+**Current Knowledge/Examples & Possible Techniques/Approaches:**  Whilst other suitable tools may exist (Mesa (Python) or Repast (Java) frameworks), our discovery work has demonstrated that [HASH](https://hash.ai/) would allow a model to be created in the timeframes for this project and that the learnings would be transferable and open.  Example simulations can be found on the [HASH website](https://hash.ai/index) as well as [a guide to using the HASH process modeling library and visual interface](https://docs.hash.ai/core/concepts/designing-with-process-models).  However, if a candidate brings experience/knowledge of an alternative open framework for building these models, then the project could focus on demonstrating a use-case through their recommended tool. 
 
 **Related Previous Internship Projects:** [SynPath](https://github.com/nhsx/SynPath)
 
 **Enables Future Work:**  Demonstration of technique feeding into further SynPath developments as well as supporting pathway analysis and system modelling programmes.
 
-**Outcome/Learning Objectives:**   A&E capacity model built in Hash or alternate framework.   Staff acting as agents deciding which patient to prioritise based on patient characteristics, current queue and A&E capacity (triage model).  Learning would highlight when benefit can be realised from this approach and how to validate the model behaviour against reality.   
+**Outcome/Learning Objectives:**   A&E capacity model built in HASH or alternate framework.   Staff acting as agents deciding which patient to prioritise based on patient characteristics, current queue and A&E capacity (triage model).  Learning would highlight when benefit can be realised from this approach and how to validate the model behaviour against reality.   
 
 **Datasets:** n/a for development, but SUS and ECDS data for validation.
 


### PR DESCRIPTION
We're delighted to see the project advertised! We're reworking our website, and I wanted to make sure that the example simulation link points to a URL that will continue to resolve correctly (and directly) to our simulation repos. I've also updated 'Hash' to 'HASH' in the copy. If you've any questions please reach out to me at david@hash.ai or leave a comment on this PR. Thanks!